### PR TITLE
Fix shelf bug and add shadow on all sides so it can look forward on both sides

### DIFF
--- a/index.css
+++ b/index.css
@@ -163,7 +163,8 @@ p {
 .blue:hover, .blue:focus {
   width: 50px;
   height: 93px;
-  box-shadow: -6px 16px 15px rgb(14, 3, 32);
+  box-shadow: 0 0 15px 8px rgb(14, 3, 32);
+  isolation: isolate;
 }
 
 .blue p {

--- a/index.css
+++ b/index.css
@@ -125,7 +125,8 @@ p {
 .red:hover, .red:focus {
   width: 61px;
   height: 112px;
-  box-shadow: -6px 16px 15px rgb(39, 7, 2);
+  box-shadow: 0 0 15px 5.3px rgb(39, 7, 2);
+  isolation: isolate;
 }
 
 .red p {
@@ -163,7 +164,7 @@ p {
 .blue:hover, .blue:focus {
   width: 50px;
   height: 93px;
-  box-shadow: 0 0 15px 8px rgb(14, 3, 32);
+  box-shadow: 0 0 15px 5.3px rgb(14, 3, 32);
   isolation: isolate;
 }
 
@@ -203,7 +204,9 @@ p {
 .green:hover, .green:focus {
   width: 40px;
   height: 80px;
-  box-shadow: -6px 16px 15px rgb(1, 47, 19);
+  box-shadow: -6px 16px 15px;
+  box-shadow: 0 0 15px 5.3px rgb(1, 47, 19);
+  isolation: isolate;
 }
 
 .green p {

--- a/src/main.js
+++ b/src/main.js
@@ -38,6 +38,8 @@ const loadShelves = () => {
     }
   } else {
     shelfOne.innerHTML = ``
+    shelfTwo.innerHTML = ``
+    shelfThree.innerHTML = ``
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -26,11 +26,14 @@ const loadShelves = () => {
   if(savedBooks > 0) {
     for(let i = 0; i < savedBooks; i++) {
       if(i <= 10) {
-        shelfOne.innerHTML += `<article class=${randomizeBook()} tabIndex="0"><p>${titles && titles[i]}</p></article>`
+        shelfOne.innerHTML += 
+        `<article id={Math.random().toString(36).substr(2, 9)} class=${randomizeBook()} tabIndex="0">
+          <p>${titles && titles[i]}</p>
+        </article>`
       } else if (i >= 11 && i < 21 ) {
-        shelfTwo.innerHTML += `<article class=${randomizeBook()} tabIndex="0"></article>`
+        shelfTwo.innerHTML += `<article id={Math.random().toString(36).substr(2, 9)} class=${randomizeBook()} tabIndex="0"></article>`
       } else {
-        shelfThree.innerHTML += `<article class=${randomizeBook()} tabIndex="0"></article>`
+        shelfThree.innerHTML += `<article id={Math.random().toString(36).substr(2, 9)} class=${randomizeBook()} tabIndex="0"></article>`
       }
     }
   } else {


### PR DESCRIPTION
This PR fixes the bug where if you filled up all the shelves, and then when you clicked clear, it only erased the top one. I did it by emptying all of the shelves innerHTML and made them empty strings. I also added box shadows to all sides and used the css property isolation: isolate, in order to have the book look like it's coming forward on all sides instead of just one. I added an ID to the books, so that I may at some point be able to remove them by click.