### PR TITLE
Feature/user picks color

### DIFF
--- a/index.css
+++ b/index.css
@@ -102,13 +102,13 @@ p {
   background-color: rgb(252, 160, 160);
 }
 
-.added-user-color-blue {
+/* .added-user-color-blue {
   background-color: blue;
 }
 
 .added-lighter-blue {
   background-color: rgb(145, 145, 254);
-}
+} */
 
 .added-user-color-yellow {
   background-color: yellow;

--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html>
   <head>
     <link rel="stylesheet" href="index.css">
+    <link rel="stylesheet" href="roomColorOne.css">
+    <link rel="stylesheet" href="roomColorTwo.css">
+    <link rel="stylesheet" href="roomColorThree.css">
   </head>
   <body>
     <aside class="user-aside" id="userLeftWall">

--- a/roomColorOne.css
+++ b/roomColorOne.css
@@ -1,0 +1,7 @@
+.added-user-color-blue {
+  background-color: blue;
+}
+
+.added-lighter-blue {
+  background-color: rgb(145, 145, 254);
+}

--- a/roomColorThree.css
+++ b/roomColorThree.css
@@ -1,0 +1,7 @@
+.added-user-color-green {
+  background-color: green;
+}
+
+.added-lighter-green {
+  background-color: rgb(171, 222, 171);
+}

--- a/roomColorTwo.css
+++ b/roomColorTwo.css
@@ -1,0 +1,7 @@
+.added-user-color-yellow {
+  background-color: yellow;
+}
+
+.added-lighter-yellow {
+  background-color: rgb(255, 255, 202);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -27,20 +27,30 @@ const updateBookCount = () => {
 
 const changeToSelectedColor = (e, color) => {
 
+  //What color the user picks, if the wall is not that color, or does not equal that color, then...
+
+  //remove it from the classlist list?
+ 
+
   const leftWallIsColored = userLeftWall.classList.contains(`added-user-color-${color}`)
   const dropdownIsColored =  dropdown.classList.contains(`added-user-color-${color}`)
   const panelIsColored = dropdownPanel.classList.contains(`added-user-color-${color}`)
 
-  if(leftWallIsColored && dropdownIsColored && panelIsColored) {
-    userLeftWall.classList.remove(`added-user-color-${color}`)
+  if(!leftWallIsColored) {
+    userLeftWall.classList.remove(...userLeftWall.classList)
     dropdownPanel.classList.remove(`added-user-color-${color}`)
     dropdown.classList.remove(`added-user-color-${color}`)
   }
+
+
 
   userLeftWall.classList.add(`added-user-color-${color}`)
   userRoom.classList.add(`added-lighter-${color}`)
   dropdownPanel.classList.add(`added-user-color-${color}`)
   dropdown.classList.add(`added-user-color-${color}`)
+
+  //if the color the user picks does not equal the color the wall is currently, remove that color
+  //When the user clicks a new one?
 }
 
 const addSelectedColor = (e) => {

--- a/src/main.js
+++ b/src/main.js
@@ -37,9 +37,9 @@ const changeToSelectedColor = (e, color) => {
   const panelIsColored = dropdownPanel.classList.contains(`added-user-color-${color}`)
 
   if(!leftWallIsColored) {
-    userLeftWall.classList.remove(...userLeftWall.classList)
-    dropdownPanel.classList.remove(`added-user-color-${color}`)
-    dropdown.classList.remove(`added-user-color-${color}`)
+    userLeftWall.classList.remove(userLeftWall.classList[1])
+    dropdownPanel.classList.remove(dropdownPanel.classList[1])
+    dropdown.classList.remove(dropdown.classList[1])
   }
 
 


### PR DESCRIPTION
This PR makes it so that instead of adding a collection of all the classnames whenever the user picks a color, instead it automatically removes the color as soon as the user picks another one, and so it only ever has one chosen user color on it, and so then the user can go back in forth because the list has to follow CSS rules of cascading, but if the color is removed when the user picks another one, then it only has to keep track of one rule.